### PR TITLE
サイドバー、グループ部分の修正

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,4 +4,12 @@ class Group < ApplicationRecord
   has_many :messages
   
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.content? ? last_message.content : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -16,4 +16,4 @@
           .group__name
             = group.name
           .group__message
-            メッセージはまだありません
+            = group.show_last_message


### PR DESCRIPTION
# What
サイドバーのグループ部分に最新のメッセージが表示されるようにコードを修正しました。
また、メッセージがないときは「まだメッセージはありません」と表示されるように修正しました。
# Why
最新のメッセージについて、文章が投稿されている場合、画像が投稿されている場合、まだ投稿がされていない場合が考えられるからです。