### PR TITLE
メッセージ画像添付のサイズ変更

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -4,7 +4,7 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   include CarrierWave::MiniMagick
 
-  process resize_to_fit: [800, 800]
+  process resize_to_fit: [200, 200]
   
   # Choose what kind of storage to use for this uploader:
   storage :file


### PR DESCRIPTION
# What
メッセージを送信する際の画像表示サイズの変更をします。

# Why
画像を最適なサイズで表示させ、webサイト全体のバランスを調整する為。