### PR TITLE
メッセージ表示画面の曜日、時刻表示の修正

### DIFF
--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -3,7 +3,7 @@
     .chat-main__messages__message__upper-info--talker
       = message.user.name
     .chat-main__messages__message__upper-info--data
-      = message.created_at.strftime("%Y/%m/%d %H:%M")
+      = message.created_at.strftime("%Y/%m/%d/(%a) %T")
   .chat-main__messages__message--text
     - if message.content.present?
       %p.lower-message__content


### PR DESCRIPTION
# What
メッセージ送信曜日の表示及び時刻を秒数まで表示ができるよう、コードを追加修正しました。

# Why
仕様書に合わせる為です。