### PR TITLE
メッセージ送信機能の非同期通信設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,5 @@ gem 'haml-rails'
 gem "font-awesome-rails"
 
 gem 'devise'
+
+gem 'rails-ujs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,8 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.2.0)
       loofah (~> 2.2, >= 2.2.2)
+    rails-ujs (0.1.0)
+      railties (>= 3.1)
     railties (5.0.7.2)
       actionpack (= 5.0.7.2)
       activesupport (= 5.0.7.2)
@@ -271,6 +273,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   rails-controller-testing
+  rails-ujs
   rmagick
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -34,8 +34,7 @@ $(function(){
     .done(function(message){
       var html = buildHTML(message);
       $('.chat-main__messages').append(html);
-      $('#message_image').val('');
-      $('#message_content').val('');
+      $('#new_message')[0].reset();
       $('.chat-main__messages').animate({scrollTop: $('.chat-main__messages')[0].scrollHeight}, 'fast');
     })
     .fail(function(message){

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,49 @@
+$(function(){
+  function buildHTML(message){
+    var img = message.image ? `<img src= ${ message.image }>` : "";
+    var html = `<div class="chat-main__messages__message">
+                  <div class="chat-main__messages__message__upper-info">
+                    <div class="chat-main__messages__message__upper-info--talker">
+                      ${message.user_name}
+                    </div>
+                    <div class="chat-main__messages__message__upper-info--data">
+                      ${message.data}
+                    </div>
+                  </div>
+                  <div class="chat-main__messages__message--text">
+                    <p class="lower-message__content">
+                      ${message.content}
+                    </p>
+                      ${img}
+                  </div>
+                </div>`
+    return html;
+  }
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(message){
+      var html = buildHTML(message);
+      $('.chat-main__messages').append(html);
+      $('#message_image').val('');
+      $('#message_content').val('');
+      $('.chat-main__messages').animate({scrollTop: $('.chat-main__messages')[0].scrollHeight}, 'fast');
+    })
+    .fail(function(message){
+      alert('メッセージを入力してください');
+      $('.chat-main__form__new_messages--submit-btn').prop('disabled', false);
+    })
+    .always(function(message){
+      $('.chat-main__form__new_messages--submit-btn').prop('disabled', false);
+    })
+  })
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(params[:group_id]) }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.user_name @message.user.name
+json.data @message.created_at.strftime("%Y/%m/%d/(%a) %T")
+json.content @message.content
+json.image @message.image.url
+json.id @message.group_id


### PR DESCRIPTION
# What
メッセージ送信の非同期通信ができるよう、必要なファイルの追加、コードの記述をしました。

・テキストのみ送信＋エラー表示動画
https://gyazo.com/792dce17ef8d85fce917114e09754843

・画像のみ送信＋エラー表示動画
https://gyazo.com/cabd4af33bf04ed4d23386e0ca63bb24

・テキスト＋画像の送信動画
https://gyazo.com/cdeec62c64dcff5c85ab95dfa18331b2

・連続送信動画
https://gyazo.com/906607a9cddda3461dfaad3866cf5852

# Why
通常のメッセージ送信では毎回リロードされ時間がかかる為、非同期通信を設定し、
レスポンスの改善及びPCno処理量を最小化する為です。